### PR TITLE
Added sleep in main packet loop

### DIFF
--- a/bin/user/davisconsoleapi.py
+++ b/bin/user/davisconsoleapi.py
@@ -2238,7 +2238,7 @@ class DavisConsoleAPIDriver(weewx.drivers.AbstractDevice):
 
         
         while True:
-            
+              time.sleep(10)
               while (self.timeout < time.time()):
 
                 now = int(time.time() + 0.5)


### PR DESCRIPTION
Sleep lowers cpu load by testing polling time only every 10 seconds.